### PR TITLE
Update Go version URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN sudo apt update && \
     sudo apt install -y wget build-essential
 
 # install latest Go
-RUN wget -q -c "https://dl.google.com/go/$(curl https://golang.org/VERSION?m=text).linux-amd64.tar.gz" -O - | sudo tar xvz -C /usr/local
+RUN wget -q -c "https://dl.google.com/go/$(curl -f -L --no-progress-meter https://go.dev/VERSION?m=text).linux-amd64.tar.gz" -O - | sudo tar xvz -C /usr/local
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 


### PR DESCRIPTION
The URL `https://golang.org/VERSION` redirects to `https://go.dev/VERSION` since a couple of months.
`curl` fails because it does not follow redirects by default.
Moreover, I added `--fail` to prevent garbage output, `--location` to follow redirects, and `--no-progress-meter` to suppress verbose output.